### PR TITLE
added additional flags and propagated to launchers

### DIFF
--- a/src/Launcher/Launcher.jl
+++ b/src/Launcher/Launcher.jl
@@ -387,6 +387,8 @@ function launch!(
     max_iter  :: Int64   = 30,
     eval      :: Int64   = 25,
     loops     :: Int64   = 1,
+    parquet   :: Bool    = true, 
+    Σ_corr    :: Bool    = true,
     initial   :: Float64 = 5.0,
     final     :: Float64 = 0.5,
     bmin      :: Float64 = 0.02,
@@ -452,10 +454,12 @@ function launch!(
         init_action!(l, r, a)
 
         # initialize by parquet iterations
-        println()
-        println("Warming up with some parquet iterations, this may take a while ...")
-        launch_parquet!(obs_file, cp_file, symmetry, l, r, m, a, initial, bmax * initial, β, max_iter, eval, S = S, N = N)
-        println("Done. Action is initialized with parquet solution.")
+        if parquet
+            println()
+            println("Warming up with some parquet iterations, this may take a while ...")
+            launch_parquet!(obs_file, cp_file, symmetry, l, r, m, a, initial, bmax * initial, β, max_iter, eval, S = S, N = N)
+            println("Done. Action is initialized with parquet solution.")
+        end
 
         println()
         println("Solver is ready.")
@@ -470,7 +474,7 @@ function launch!(
         elseif loops == 2
             launch_2l!(obs_file, cp_file, symmetry, l, r, m, a, initial, final, bmax * initial, bmin, bmax, eval, wt, ct, S = S, N = N)
         elseif loops >= 3
-            launch_ml!(obs_file, cp_file, symmetry, l, r, m, a, loops, initial, final, bmax * initial, bmin, bmax, eval, wt, ct, S = S, N = N)
+            launch_ml!(obs_file, cp_file, symmetry, l, r, m, a, loops, Σ_corr, initial, final, bmax * initial, bmin, bmax, eval, wt, ct, S = S, N = N)
         end 
     else
         println("overwrite = false, trying to load data ...")
@@ -516,7 +520,7 @@ function launch!(
                 elseif loops == 2
                     launch_2l!(obs_file, cp_file, symmetry, l, r, m, a, Λ, final, dΛ, bmin, bmax, eval, wt, ct, S = S, N = N)
                 elseif loops >= 3
-                    launch_ml!(obs_file, cp_file, symmetry, l, r, m, a, loops, Λ, final, dΛ, bmin, bmax, eval, wt, ct, S = S, N = N)
+                    launch_ml!(obs_file, cp_file, symmetry, l, r, m, a, loops, Σ_corr, Λ, final, dΛ, bmin, bmax, eval, wt, ct, S = S, N = N)
                 end 
             end 
         else 

--- a/src/Launcher/launcher_ml.jl
+++ b/src/Launcher/launcher_ml.jl
@@ -7,6 +7,7 @@ function launch_ml!(
     m        :: mesh,
     a        :: action,
     loops    :: Int64,
+    Σ_corr   :: Bool, 
     Λi       :: Float64,
     Λf       :: Float64,
     dΛi      :: Float64,
@@ -59,7 +60,7 @@ function launch_ml!(
         # compute k1 and parse to da and a_err
         compute_dΣ!(Λ, r, m, a, a_stage)
         compute_dΓ_ml!(Λ, r, m, loops, a, a_stage, da_l, da_c, da_temp, da_Σ, tbuffs, temps, eval)
-        compute_dΣ_corr!(Λ, r, m, a, a_stage, da_Σ)
+        if Σ_corr compute_dΣ_corr!(Λ, r, m, a, a_stage, da_Σ) end
         mult_with_add_to!(a_stage, -2.0 * dΛ / 9.0, da)
         mult_with_add_to!(a_stage, -7.0 * dΛ / 24.0, a_err)
 
@@ -68,7 +69,7 @@ function launch_ml!(
         mult_with_add_to!(a_stage, -0.5 * dΛ, a_inter)
         compute_dΣ!(Λ - 0.5 * dΛ, r, m, a_inter, a_stage)
         compute_dΓ_ml!(Λ - 0.5 * dΛ, r, m, loops, a_inter, a_stage, da_l, da_c, da_temp, da_Σ, tbuffs, temps, eval) 
-        compute_dΣ_corr!(Λ - 0.5 * dΛ, r, m, a_inter, a_stage, da_Σ)
+        if Σ_corr compute_dΣ_corr!(Λ - 0.5 * dΛ, r, m, a_inter, a_stage, da_Σ) end
         mult_with_add_to!(a_stage, -1.0 * dΛ / 3.0, da)
         mult_with_add_to!(a_stage, -1.0 * dΛ / 4.0, a_err)
 
@@ -77,7 +78,7 @@ function launch_ml!(
         mult_with_add_to!(a_stage, -0.75 * dΛ, a_inter)
         compute_dΣ!(Λ - 0.75 * dΛ, r, m, a_inter, a_stage)
         compute_dΓ_ml!(Λ - 0.75 * dΛ, r, m, loops, a_inter, a_stage, da_l, da_c, da_temp, da_Σ, tbuffs, temps, eval)
-        compute_dΣ_corr!(Λ - 0.75 * dΛ, r, m, a_inter, a_stage, da_Σ)
+        if Σ_corr compute_dΣ_corr!(Λ - 0.75 * dΛ, r, m, a_inter, a_stage, da_Σ) end
         mult_with_add_to!(a_stage, -4.0 * dΛ / 9.0, da)
         mult_with_add_to!(a_stage, -1.0 * dΛ / 3.0, a_err)
 
@@ -85,7 +86,7 @@ function launch_ml!(
         replace_with!(a_inter, da)
         compute_dΣ!(Λ - dΛ, r, m, a_inter, a_stage)
         compute_dΓ_ml!(Λ - dΛ, r, m, loops, a_inter, a_stage, da_l, da_c, da_temp, da_Σ, tbuffs, temps, eval)
-        compute_dΣ_corr!(Λ - dΛ, r, m, a_inter, a_stage, da_Σ)
+        if Σ_corr compute_dΣ_corr!(Λ - dΛ, r, m, a_inter, a_stage, da_Σ) end
         mult_with_add_to!(a_stage, -1.0 * dΛ / 8.0, a_err)
 
         # estimate integration error 


### PR DESCRIPTION
`launch!` has two more boolean flags `parquet` and `Σ_corr` which default to `true`. With these, parquet iterations to initialize the FRG flow as well as self-energy corrections in multiloop runs can be turned if wanted. However, this is not recommend (therefore both arguments default to true).