### PR TITLE
Enforce output

### DIFF
--- a/src/Launcher/Launcher.jl
+++ b/src/Launcher/Launcher.jl
@@ -557,6 +557,7 @@ function launch!(
         if parquet
             println()
             println("Warming up with some parquet iterations ...")
+            flush(stdout)
             launch_parquet!(obs_file, cp_file, symmetry, l, r, m, a, initial, bmax * initial, β, max_iter, eval, S = S)
             println("Done. Action is initialized with parquet solution.")
         end
@@ -568,6 +569,7 @@ function launch!(
 
         # start calculation
         println("Renormalization group flow with ℓ = $(loops) ...")
+        flush(stdout)
 
         if loops == 1
             launch_1l!(obs_file, cp_file, symmetry, l, r, m, a, p, initial, final, bmax * initial, bmin, bmax, eval, wt, ct, S = S)
@@ -594,6 +596,7 @@ function launch!(
                 println()
                 println("Calculation has finished already.")
                 println("#------------------------------------------------------------------------------------------------------#")
+                flush(stdout)
             else
                 println("Final Λ has not been reached, resuming calculation ...")
 
@@ -614,6 +617,7 @@ function launch!(
 
                 # resume calculation
                 println("Renormalization group flow with ℓ = $(loops) ...")
+                flush(stdout)
 
                 if loops == 1
                     launch_1l!(obs_file, cp_file, symmetry, l, r, m, a, p, Λ, final, dΛ, bmin, bmax, eval, wt, ct, S = S)
@@ -627,6 +631,7 @@ function launch!(
             println()
             println("Found no existing output files, terminating solver ...")
             println("#------------------------------------------------------------------------------------------------------#")
+            flush(stdout)
         end
     end
 
@@ -634,6 +639,7 @@ function launch!(
     println("#------------------------------------------------------------------------------------------------------#")
     println("Solver terminated.")
     println("#------------------------------------------------------------------------------------------------------#")
+    flush(stdout)
 
     return nothing
 end

--- a/src/Launcher/launcher_1l.jl
+++ b/src/Launcher/launcher_1l.jl
@@ -44,6 +44,7 @@ function launch_1l!(
     while Λ > Λf
         println()
         println("ODE step at cutoff Λ / |J| = $(Λ) ...")
+        flush(stdout)
 
         # prepare da and a_err
         replace_with!(da, a)
@@ -148,6 +149,7 @@ function launch_1l!(
     close(cp)
 
     println("Renormalization group flow finished.")
+    flush(stdout)
 
     return nothing
 end

--- a/src/Launcher/launcher_2l.jl
+++ b/src/Launcher/launcher_2l.jl
@@ -47,6 +47,7 @@ function launch_2l!(
     while Λ > Λf
         println()
         println("ODE step at cutoff Λ / |J| = $(Λ) ...")
+        flush(stdout)
 
         # prepare da and a_err
         replace_with!(da, a)
@@ -151,6 +152,7 @@ function launch_2l!(
     close(cp)
 
     println("Renormalization group flow finished.")
+    flush(stdout)
 
     return nothing
 end

--- a/src/Launcher/launcher_ml.jl
+++ b/src/Launcher/launcher_ml.jl
@@ -52,6 +52,7 @@ function launch_ml!(
     while Λ > Λf
         println()
         println("ODE step at cutoff Λ / |J| = $(Λ) ...")
+        flush(stdout)
 
         # prepare da and a_err
         replace_with!(da, a)
@@ -160,6 +161,7 @@ function launch_ml!(
     close(cp)
 
     println("Renormalization group flow finished.")
+    flush(stdout)
 
     return nothing
 end

--- a/src/Launcher/parquet.jl
+++ b/src/Launcher/parquet.jl
@@ -43,6 +43,7 @@ function launch_parquet!(
         rel_err = abs_err / max(get_abs_max(a), get_abs_max(ap))
 
         println("After iteration $(count), abs_err, rel_err = $(abs_err), $(rel_err).")
+        flush(stdout)
 
         # update current solution using damping factor β
         mult_with!(a, 1 - β)
@@ -57,6 +58,8 @@ function launch_parquet!(
     else
         println("Maximum number of iterations reached, final abs_err, rel_err = $(abs_err), $(rel_err).")
     end
+    
+    flush(stdout)
 
     # save final result
     measure(symmetry, obs_file, cp_file, Λ, dΛ, Dates.now(), Dates.now(), r, m, a, Inf, 0.0)


### PR DESCRIPTION
Closes #39 

Added flush(stdout) in strategic places to force writing output. needed for SUPERMUC, as buffers there do not seem to flush themselves before finishing execution.