### PR TITLE
Hotfix for SLURM interface

### DIFF
--- a/src/Launcher/Launcher.jl
+++ b/src/Launcher/Launcher.jl
@@ -102,7 +102,7 @@ end
         num_σ     :: Int64              = 50,
         num_Ω     :: Int64              = 15,
         num_ν     :: Int64              = 10,
-        p         :: NTuple{5, Float64} = (0.4, 0.1, 0.2, 0.05, 2.0),
+        p         :: NTuple{5, Float64} = (0.4, 0.15, 0.25, 0.05, 2.0),
         max_iter  :: Int64              = 30,
         eval      :: Int64              = 30,
         loops     :: Int64              = 1,
@@ -134,7 +134,7 @@ function save_launcher!(
     num_σ     :: Int64              = 50,
     num_Ω     :: Int64              = 15,
     num_ν     :: Int64              = 10,
-    p         :: NTuple{5, Float64} = (0.4, 0.1, 0.2, 0.05, 2.0),
+    p         :: NTuple{5, Float64} = (0.4, 0.15, 0.25, 0.05, 2.0),
     max_iter  :: Int64              = 30,
     eval      :: Int64              = 30,
     loops     :: Int64              = 1,
@@ -238,7 +238,7 @@ function make_job!(
 
     open(path, "w") do file
         # set SLURM parameters
-        write(file, "#!/bin/bash -l \n")
+        write(file, "#!/bin/bash \n")
 
         for arg in keys(args)
             write(file, "#SBATCH --$(arg)=$(args[arg]) \n")
@@ -429,7 +429,7 @@ include("launcher_ml.jl")
         num_σ     :: Int64              = 50,
         num_Ω     :: Int64              = 15,
         num_ν     :: Int64              = 10,
-        p         :: NTuple{5, Float64} = (0.4, 0.1, 0.2, 0.05, 2.0),
+        p         :: NTuple{5, Float64} = (0.4, 0.15, 0.25, 0.05, 2.0),
         max_iter  :: Int64              = 30,
         eval      :: Int64              = 30,
         loops     :: Int64              = 1,
@@ -458,7 +458,7 @@ Runs the FRG solver. A detailed explanation of the solver parameters is given be
 * `num_ν`     : number of non-zero, positive frequencies for the fermionic axis of the two-particle irreducible channels
 * `p`         : parameters for updating frequency meshes between ODE steps \n
                 p[1] gives the percentage of linearly spaced frequencies (0.0 < p[1] < 1.0).
-                p[2] (p[3]) sets the lower (upper) bound for the accepted relative deviation of the first finite frequency to the origin (0.0 < p[2] < p[3] < 0.3).
+                p[2] (p[3]) sets the lower (upper) bound for the accepted relative deviation of the first finite frequency to the origin (0.0 < p[2] < p[3] < 0.35).
                 p[4] (p[5]) sets the lower (upper) bound for the linear spacing in units of the cutoff Λ (0.0 < p[4] < p[5] < 3.0).
 * `max_iter`  : maximum number of parquet iterations
 * `eval`      : number of subdomains for adaptive quadrature routine (`20 <= eval <= 100` recommended). Lower number means loss of accuracy, higher will lead to increased runtimes.
@@ -487,7 +487,7 @@ function launch!(
     num_σ     :: Int64              = 50,
     num_Ω     :: Int64              = 15,
     num_ν     :: Int64              = 10,
-    p         :: NTuple{5, Float64} = (0.4, 0.1, 0.2, 0.05, 2.0),
+    p         :: NTuple{5, Float64} = (0.4, 0.15, 0.25, 0.05, 2.0),
     max_iter  :: Int64              = 30,
     eval      :: Int64              = 30,
     loops     :: Int64              = 1,


### PR DESCRIPTION
Removed -l startup flag for bash script and tweaked default scanning parameters to work better with other default arguments.